### PR TITLE
Allow separators in sudoers for powershell arguments or options

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,5 +56,5 @@ In command console or powershell console :<br>
 Run "sudoWs_client.exe <Path to script | Powershell command>"
 <br><br>
 If the args is not in sudoers, execution is denied.<br>
-If the args is in sudoers but not with NOPASSWD option, UAC for Adminisrator password is prompting.<br>
+If the args is in sudoers with PASSWD (or none) option, UAC for Adminisrator password is prompting.<br>
 If the args is in sudoers with NOPASSWD option, the command or script is run with elevated account (SYSTEM) and the standard output is return.<br>

--- a/sudoWs_server/sudoWs_server/getAutorization.cs
+++ b/sudoWs_server/sudoWs_server/getAutorization.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Configuration;
+using System.Text.RegularExpressions;
 
 public class GetAuthorization
 {
@@ -8,13 +9,15 @@ public class GetAuthorization
     {
 		string file = System.IO.File.ReadAllText(ConfigurationManager.AppSettings.Get("sudoers"));
 		string[] readPriviledges = file.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+		string sudoersPattern = @"^(u|g);(.*?);(.*);($|NOPASSWD$|PASSWD$)";
 
 		List<String[]> privilegesList = new List<String[]>();
 		for (int i = 0; i < readPriviledges.Length; i++)
 		{
-			if (readPriviledges[i].Split(";").Length >= 3 && readPriviledges[i].Split(";").Length <= 4)
+			if(Regex.IsMatch(readPriviledges[i], sudoersPattern))
 			{
-				privilegesList.Add(readPriviledges[i].Split(";"));
+				Match matchSyntax = Regex.Match(readPriviledges[i], sudoersPattern);
+				privilegesList.Add(new[] { matchSyntax.Groups[1].Value, matchSyntax.Groups[2].Value, matchSyntax.Groups[3].Value, matchSyntax.Groups[4].Value });
 			}
 		}
 
@@ -29,21 +32,25 @@ public class GetAuthorization
 		foreach(String[] priviledge in privileges)
         {
 			if(priviledge[0] == "u" && priviledge[1] == username)
-            {
+			{
 				if (priviledge[2] == commandLine)
-                {
+				{
 					if(priviledge[3] == "NOPASSWD")
-                    {
+					{
 						return 0;
 					}
-                    else
-                    {
+					else if(priviledge[3] == "PASSWD" || priviledge[3] == "") 
+					{
 						return 1;
 					}
-                }
-            }
-            else if(priviledge[0] == "g")
-            {
+					else
+					{
+						return 2;
+					}
+				}
+			}
+			else if(priviledge[0] == "g")
+			{
 				bool isAMember = GetUserInfo.IsUserGroupMember(username, priviledge[1]);
 
 				if (priviledge[2] == commandLine && isAMember)

--- a/sudoers/sudoers.txt
+++ b/sudoers/sudoers.txt
@@ -1,13 +1,15 @@
-### !!!Please ensure this file is only readable by Windows administrators!!!T
-###This file is the whitelist commands or scripts for sudoWs
+### !!!Please ensure this file is only readable by Windows administrators!!!
+### This file is the whitelist commands or scripts for sudoWs
 ###
 ### Format is the following :
-### [u|g];[username|groupname];[powershell command|path to powershell script];[NOPASSWD]
+### [u|g];[username|groupname];[powershell command|path to powershell script];[|PASSWD|NOPASSWD]
+###
+### HINT : format must match regex ^(u|g);(.*?);(.*);($|NOPASSWD$|PASSWD$)
 ###
 ### 1) u for user, g for group
 ### 2) username if u in 1), group name otherwise
 ### 3) Command or script that will be literally executed in a powershell call
-### 3) NOPASSWD : do not prompt administrator password. Other value will ask for adminisrator password
+### 3) NOPASSWD : do not prompt administrator password. PASSWD or no option will ask for adminisrator password
 ###
 ### Format is case sensitive
 ###


### PR DESCRIPTION
Sudoers line must match regex ^(u|g);(.*?);(.*);($|NOPASSWD$|PASSWD$)